### PR TITLE
Add Github command to provide repository link

### DIFF
--- a/src/main/java/de/simonisinger/CommandListener.java
+++ b/src/main/java/de/simonisinger/CommandListener.java
@@ -20,6 +20,7 @@ public class CommandListener extends ListenerAdapter {
         commands.add(new RemoveChannelCommand());
         commands.add(new ListFeedsCommand());
         commands.add(new InviteCommand());
+        commands.add(new GithubCommand());
     }
 
     @Override

--- a/src/main/java/de/simonisinger/commands/GithubCommand.java
+++ b/src/main/java/de/simonisinger/commands/GithubCommand.java
@@ -1,0 +1,22 @@
+package de.simonisinger.commands;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+
+public class GithubCommand implements Command {
+	@Override
+	public String getName() {
+		return "github";
+	}
+
+	@Override
+	public SlashCommandData build() {
+		return Commands.slash(this.getName(), "Link to the Github repository");
+	}
+
+	@Override
+	public void handle(SlashCommandInteractionEvent event) {
+		event.reply("https://github.com/simonisinger/anisearch-discord-merch-fetcher").setEphemeral(true).queue();
+	}
+}


### PR DESCRIPTION
This commit introduces a new `GithubCommand` and registers it in `CommandListener`. The command allows users to retrieve a link to the project's GitHub repository via a slash command. It ensures a quick, user-friendly way to access the repository.